### PR TITLE
Fix: 투표 불가 오류 수정

### DIFF
--- a/src/main/java/world/startoy/polling/domain/Vote.java
+++ b/src/main/java/world/startoy/polling/domain/Vote.java
@@ -2,7 +2,11 @@ package world.startoy.polling.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -14,7 +18,6 @@ import java.time.LocalDateTime;
 public class Vote {
 
     @Id
-    @NotNull
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "vote_id", nullable = false)
     private Long id;

--- a/src/main/java/world/startoy/polling/usecase/VoteService.java
+++ b/src/main/java/world/startoy/polling/usecase/VoteService.java
@@ -77,6 +77,7 @@ public class VoteService {
                 .pollId(poll.getId())
                 .optionId(selectedOption.getId())
                 .voterIp(voterIp)
+                .createdAt(LocalDateTime.now())
                 .build();
         voteRepository.save(vote);
 


### PR DESCRIPTION
# 🐛 Fix: 투표 불가 오류 수정
- 필수값 누락
- @GeneratedValue를 사용하여 자동으로 생성되는 id 필드에 @NotNull을 사용하면 JPA가 자동으로 값을 할당하기 전에 null 검사로 인해 유효성 검사가 실패할 수 있습니다.